### PR TITLE
Add setting to specify timezone

### DIFF
--- a/ConvertEpochToDate.sublime-settings
+++ b/ConvertEpochToDate.sublime-settings
@@ -2,7 +2,11 @@
     // in-place replacement to date
     "in_place_replacement": true,
     // defines custom output date format. visit http://strftime.org for possible format directives
-    "output_date_format": "%a %d %b %Y %I:%M:%S %p",
+    "output_date_format": "%a %d %b %Y %I:%M:%S %Z %p",
+    // defines timezone to convert to. for a list of timezones visit https://en.wikipedia.org/wiki/List_of_tz_database_time_zones 
+    // if undefined or set to an invalid timezone, the system time is used. 
+    // e.g. "UTC", "America/Los_Angeles"
+    "timezone": "",
     // appends milliseconds at the end of output date
     "show_milliseconds": true,
     // shows message box for output date

--- a/README.md
+++ b/README.md
@@ -47,7 +47,12 @@ Following parameters can be overridden in User Settings file (_Preferences > Pac
     "in_place_replacement": true,
 
     // defines custom output date format. visit strftime.org for possible format directives
-    "output_date_format": "%a %d %b %Y %I:%M:%S %p",
+    "output_date_format": "%a %d %b %Y %I:%M:%S %Z %p",
+
+    // defines timezone to convert to. for a list of timezones visit https://en.wikipedia.org/wiki/List_of_tz_database_time_zones 
+    // if undefined or set to an invalid timezone, the system time is used. 
+    // e.g. "UTC", "America/Los_Angeles"
+    "timezone": "",
 
     // if set to true, appends milliseconds at the end of output date
     "show_milliseconds": true,

--- a/convert_epoch_to_date.py
+++ b/convert_epoch_to_date.py
@@ -2,6 +2,8 @@ import sublime
 import sublime_plugin
 import re
 from datetime import datetime
+# TODO: switch to zoneinfo after upgrading to Python 3.9
+import pytz
 
 def get_settings(string):
     return sublime.load_settings("ConvertEpochToDate.sublime-settings").get(string)
@@ -9,17 +11,28 @@ def get_settings(string):
 class ConvertEpochToDateCommand(sublime_plugin.TextCommand):
     def run(self, edit):
         view = self.view
-        msg = ""
+        msgs = []
         for region in view.sel():
             if region.empty(): region = view.word(region)
             epoch_text = view.substr(region)
             if epoch_text and re.match(r'^(\d{10,13})$', epoch_text):
+
+                dt = datetime.fromtimestamp(int(epoch_text[0:10]))
+                dt = dt.astimezone()
+
+                tz_pref = get_settings("timezone")
+                if tz_pref:
+                    try: dt = dt.astimezone(pytz.timezone(tz_pref))
+                    except pytz.UnknownTimeZoneError:
+                        msgs.append(f""" (Warning: Invalid timezone "{tz_pref}" defined, using local time)""")
+
                 output_date_format = get_settings("output_date_format")
-                try: result = datetime.fromtimestamp(int(epoch_text[0:10])).strftime(output_date_format)
+                try: 
+                    result = dt.strftime(output_date_format)
                 except ValueError:
-                    msg = f""" (Warning: Invalid format string "{output_date_format}" defined, using default)"""
-                    output_date_format = "%a %d %b %Y %I:%M:%S %p"
-                    result = datetime.fromtimestamp(int(epoch_text[0:10])).strftime(output_date_format)
+                    msgs.append(f""" (Warning: Invalid format string "{output_date_format}" defined, using default)""")
+                    output_date_format = "%a %d %b %Y %I:%M:%S %Z %p"
+                    result = dt.strftime(output_date_format)
 
                 if result:
                     if get_settings("show_milliseconds"):
@@ -28,14 +41,14 @@ class ConvertEpochToDateCommand(sublime_plugin.TextCommand):
 
                     if view.is_read_only():
                         if not get_settings("show_message_box") and get_settings("show_message_box_for_readonly"): sublime.message_dialog(result)
-                        msg = f""" (Warning: View readonly{", can't make in-place replacement" if get_settings("in_place_replacement") else ""})"""
-                    elif not get_settings("in_place_replacement"): msg = " (Warning: in-place replacement disabled)"
+                        msgs.append(""" (Warning: View readonly{", can't make in-place replacement" if get_settings("in_place_replacement") else ""})""")
+                    elif not get_settings("in_place_replacement"): msgs.append(" (Warning: in-place replacement disabled)")
                     else: view.replace(edit, region, result)
 
                     if get_settings("show_message_box"): sublime.message_dialog(result)
 
-                    msg = f"ConvertEpochToDate: {result}{msg}"
-                else: msg = f"ConvertEpochToDate: Conversion error"
-            else: msg = f"""ConvertEpochToDate: Invalid epoch timestamp: "{epoch_text}"; must be 10-13 digits"""
+                    msgs.append(f"ConvertEpochToDate: {result}")
+                else: msgs.append(f"ConvertEpochToDate: Conversion error")
+            else: msgs.append(f"""ConvertEpochToDate: Invalid epoch timestamp: "{epoch_text}"; must be 10-13 digits""")
 
-            sublime.status_message(msg)
+            sublime.status_message(" ".join(msgs))


### PR DESCRIPTION
Also make default time format to include tz information.

--- 
Hey, love the project! I just used it a bunch while debugging log files locally. I needed to view the time in UTC though for comparison to other metrics/logs. 

I've got it working for me but thought I'd make a pull request incase you think its a helpful addition. 

Couple things
- Left the message updates to you but I can update if you'd like
- I added a dependency on pytz. Locally I was able to get the dependency using a `dependencies.json` file, but when publishing to Package Control looks like there may be an extra step: https://packagecontrol.io/docs/dependencies/ 